### PR TITLE
Fix for 'ERROR_INVALID_EMAIL'

### DIFF
--- a/lib/screens/registration_screen.dart
+++ b/lib/screens/registration_screen.dart
@@ -74,7 +74,7 @@ class _RegistrationScreenState extends State<RegistrationScreen> {
                   });
                   try {
                     final newUser = await _auth.createUserWithEmailAndPassword(
-                        email: email, password: password);
+                        email: email.trim(), password: password);
                     if (newUser != null) {
                       Navigator.pushNamed(context, ChatScreen.id);
                     }


### PR DESCRIPTION
If the code is tested on a Windows machine (maybe Mac too) and the user switches to password field using 'Tab' instead of using the mouse, the email entry may get rejected due to presence of extra white spaces. This small change should fix the problem.