### PR TITLE
Update chat_screen.dart

### DIFF
--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -3,8 +3,8 @@ import 'package:flash_chat/constants.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
-final _firestore = Firestore.instance;
-FirebaseUser loggedInUser;
+final _firestore = FirebaseFirestore.instance;
+User loggedInUser;
 
 class ChatScreen extends StatefulWidget {
   static const String id = 'chat_screen';


### PR DESCRIPTION
At the beginning of this page, these two lines of code are been deprecated and the correct forms are:
 ```
final _firestore = FirebaseFirestore.instance; 
User loggedInUser;
```